### PR TITLE
[FIX] Package data path errors

### DIFF
--- a/snf/info.py
+++ b/snf/info.py
@@ -38,7 +38,10 @@ EXTRAS_REQUIRE['all'] = list(set([
 ]))
 
 PACKAGE_DATA = {
-    'snfpy': ['tests/data/*']
+    'snf': [
+        'tests/data/digits/*csv',
+        'tests/data/sim/*csv'
+    ]
 }
 
 CLASSIFIERS = [


### PR DESCRIPTION
Errors loading package data upon installation (e.g., #10) are primarily due to issues in the setup. This should fix things! :crossed_fingers: 